### PR TITLE
application.rbのrails generateコマンドを修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,14 @@ module WonderfulPostApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.generators do |g|
+      g.jbuilder false
+      g.javascripts false
+      g.stylesheets false
+      g.helper false
+      g.test_framework false
+    end
+
   end
 end


### PR DESCRIPTION
##概要
- HTMLを返すアプリケーションを作成するため、余計なファイルが出来ないようrails generateコマンドを修正