### PR TITLE
記事とタグのアソシエーションを追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,5 +2,6 @@ class Article < ApplicationRecord
   validates :title, presence: true, uniqueness: { case_sensitive: false }
   validates :content, presence: true, uniqueness: { case_sensitive: false }
   belongs_to :user
-
+  has_many :tag_articles, dependent: :destroy
+  has_many :tags, through: :tag_articles
 end

--- a/app/models/tag_article.rb
+++ b/app/models/tag_article.rb
@@ -1,0 +1,4 @@
+class TagArticle < ApplicationRecord
+  belongs_to :tag
+  belongs_to :article
+end

--- a/db/migrate/20230614122023_create_tag_articles.rb
+++ b/db/migrate/20230614122023_create_tag_articles.rb
@@ -1,0 +1,10 @@
+class CreateTagArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tag_articles do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_14_115321) do
+ActiveRecord::Schema.define(version: 2023_06_14_122023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 2023_06_14_115321) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "tag_articles", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_tag_articles_on_article_id"
+    t.index ["tag_id"], name: "index_tag_articles_on_tag_id"
   end
 
   create_table "tags", force: :cascade do |t|
@@ -44,4 +53,6 @@ ActiveRecord::Schema.define(version: 2023_06_14_115321) do
   end
 
   add_foreign_key "articles", "users"
+  add_foreign_key "tag_articles", "articles"
+  add_foreign_key "tag_articles", "tags"
 end


### PR DESCRIPTION
##概要
- 中間テーブルのtag_articlesテーブルを作成
- article.rbにtag_articlesを介してタグと記事の関係性を定義